### PR TITLE
bugfix: verify range proofs

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -472,10 +472,15 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, lastKey []byte, key
 	if len(keys) != len(values) {
 		return false, fmt.Errorf("inconsistent proof data, keys: %d, values: %d", len(keys), len(values))
 	}
-	// Ensure the received batch is monotonic increasing.
+	// Ensure the received batch is monotonic increasing and contains no deletions.
 	for i := 0; i < len(keys)-1; i++ {
 		if bytes.Compare(keys[i], keys[i+1]) >= 0 {
 			return false, errors.New("range is not monotonically increasing")
+		}
+	}
+	for _, value := range values {
+		if len(value) == 0 {
+			return false, errors.New("range contains deletion")
 		}
 	}
 	// Special case, there is no edge proof at all. The given range is expected


### PR DESCRIPTION
### Description

Fix "panic: deletion not supported" bug, cherry-pick from https://github.com/ethereum/go-ethereum/pull/23960

### Rationale

Return error when range contains deletion at VerifyRangeProof, then when trie update, the deletion value won't get there, the panic won't be triggered.
