### PR TITLE
bugfix: add timeout for stopping p2p server

### DIFF
--- a/eth/protocols/diff/handshake.go
+++ b/eth/protocols/diff/handshake.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// handshakeTimeout is the maximum allowed time for the `diff` handshake to
-	// complete before dropping the connection.= as malicious.
+	// complete before dropping the connection as malicious.
 	handshakeTimeout = 5 * time.Second
 )
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -129,6 +129,16 @@ func NewPeer(id enode.ID, name string, caps []Cap) *Peer {
 	return peer
 }
 
+// NewPeerWithProtocols returns a peer for testing purposes.
+func NewPeerWithProtocols(id enode.ID, protocols []Protocol, name string, caps []Cap) *Peer {
+	pipe, _ := net.Pipe()
+	node := enode.SignNull(new(enr.Record), id)
+	conn := &conn{fd: pipe, transport: nil, node: node, caps: caps, name: name}
+	peer := newPeer(log.Root(), conn, protocols)
+	close(peer.closed) // ensures Disconnect doesn't block
+	return peer
+}
+
 // ID returns the node's public key.
 func (p *Peer) ID() enode.ID {
 	return p.rw.node.ID()


### PR DESCRIPTION
### Description

For now, when accepting p2p peers in p2p server, we will run runEthPeer and RunPeer in diffHandler and snapHandler concurrently, so sometimes runEthPeer will hang there for waiting for the signal that it missed before it runninng.

This will cause we can not stop the bsc node gracefully, so we add a timeout for stopping p2p server and a timeout for handling p2p peers.