### PR TITLE
bugfix: preimage race

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -722,17 +722,18 @@ func (db *Database) Commit(node common.Hash, report bool, callback func(common.H
 	batch := db.diskdb.NewBatch()
 
 	// Move all of the accumulated preimages into a write batch
+	db.lock.RLock()
 	if db.preimages != nil {
 		rawdb.WritePreimages(batch, db.preimages)
 		// Since we're going to replay trie node writes into the clean cache, flush out
 		// any batched pre-images before continuing.
 		if err := batch.Write(); err != nil {
+			db.lock.RUnlock()
 			return err
 		}
 		batch.Reset()
 	}
 	// Move the trie itself into the batch, flushing if enough data is accumulated
-	db.lock.RLock()
 	nodes, storage := len(db.dirties), db.dirtiesSize
 	db.lock.RUnlock()
 


### PR DESCRIPTION
### Description

Fix the race condition on preimage.

### Rationale

![image](https://user-images.githubusercontent.com/23430294/163936084-f6fa3a92-5c88-43df-98b5-4c7ab24c8046.png)

It can be fixed read lock the db when we flush preimage into storaage.
