### PR TITLE
bugfix: deadlock on miner module when failed to commit trie

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1338,10 +1338,8 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 					// Write any contract code associated with the state object
 					tasks <- func() {
 						// Write any storage changes in the state object to its storage trie
-						if err := obj.CommitTrie(s.db); err != nil {
-							taskResults <- err
-						}
-						taskResults <- nil
+						err := obj.CommitTrie(s.db)
+						taskResults <- err
 					}
 					tasksNum++
 				}


### PR DESCRIPTION
### Description

A possible deadlock when commit trie failed

### Rationale

```
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func1.1(0x40eefc8fc0, 0x0, 0x420496c2f8, 0x1, 0x1, 0x572e056600a67eff, 0x99b123d0825edb78)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1367 +0x2d4
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func1(0x0, 0x0)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1413 +0x5c
github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit.func4(0x429104c180, 0x4316b0ec80)
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1502 +0x28
created by github.com/ethereum/go-ethereum/core/state.(*StateDB).Commit
	/ext-go/1/src/github.com/ethereum/go-ethereum/core/state/statedb.go:1501 +0x200
```

Blocked in sending task to tasks channel.

The task itself will send response to taskResults, if CommitTrie failed, taskResults will get two signal, while the size of taskResults is len(s.stateObjectsDirty), which will cause the routine blocked.
