### PR TITLE
feature: disable diffsync when pipecommit is enabled

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -129,7 +129,7 @@ var (
 	}
 	PipeCommitFlag = cli.BoolFlag{
 		Name:  "pipecommit",
-		Usage: "Enable MPT pipeline commit, it will improve syncing performance. It is an experimental feature(default is false)",
+		Usage: "Enable MPT pipeline commit, it will improve syncing performance. It is an experimental feature(default is false), diffsync will be disable if pipeline commit is enabled",
 	}
 	RangeLimitFlag = cli.BoolFlag{
 		Name:  "rangelimit",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -200,7 +200,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 	)
 	bcOps := make([]core.BlockChainOption, 0)
-	if config.DiffSync {
+	// TODO diffsync performance is not as expected, disable it when pipecommit is enabled for now
+	if config.DiffSync && !config.PipeCommit {
 		bcOps = append(bcOps, core.EnableLightProcessor)
 	}
 	if config.PipeCommit {


### PR DESCRIPTION
### Description

This PR is going to disable diffsync when pipecommit is enabled.

### Rationale

After several rounds of performance improvement, it turns out the diffsync performance is no better than a pipecommit enabled node.
